### PR TITLE
add gMSA read and write file test

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 }
 
 func runTest(opTestCase OpTestCase) (string, error) {
-	runme := exec.Command("./e2e_test_binary/"+TestContext.OS+"/e2e.test", "--provider", TestContext.Provider, "--kubeconfig", TestContext.KubeConfig, "--ginkgo.focus", opTestCase.Focus[0], "--ginkgo.skip", opTestCase.Skip[0])
+	runme := exec.Command("./e2e_test_binary/"+TestContext.OS+"/e2e.test", "--provider", TestContext.Provider, "--kubeconfig", TestContext.KubeConfig, "--ginkgo.focus", opTestCase.Focus[0], "--ginkgo.skip", opTestCase.Skip[0], "--node-os-distro", "windows", "--non-blocking-taints", "os")
 	out, err := runme.CombinedOutput()
 	return string(out), err
 

--- a/tests.yaml
+++ b/tests.yaml
@@ -275,24 +275,22 @@ testCases:
   #   skip:
   #   - ''
   #   windows_image: .nan
-  # - category: activedirectory
-  #   description: Ability to run a pod as a GMSA User with only be able to access allowed
-  #     resources
-  #   focus:
-  #   - ''
-  #   linux_image: .nan
-  #   skip:
-  #   - ''
-  #   windows_image: .nan
-  # - category: activedirectory
-  #   description: Ability to read and write from local storage using ActiveDirectory
-  #     credentials
-  #   focus:
-  #   - ''
-  #   linux_image: .nan
-  #   skip:
-  #   - ''
-  #   windows_image: .nan
+  - category: activedirectory
+    description: Ability to read and write files as a GMSA User
+    focus:
+    - 'can read and write file to remote folder'
+    linux_image: .nan
+    skip:
+    - ''
+    windows_image: .nan
+  - category: activedirectory
+    description: Ability to run a pod as a GMSA User and verify if it can connect to the domain successfully
+    focus:
+    - 'works end to end'
+    linux_image: .nan
+    skip:
+    - ''
+    windows_image: .nan
   # - category: activedirectory
   #   description: The behavior of the `RunAsUserName` field for Windows pods should be
   #     that it is supported (i.e. pods can use this), but that there are no guarantees


### PR DESCRIPTION
Adding gMSA file reading and writing test case to the tests.yaml. The upstream test(https://github.com/kubernetes/kubernetes/pull/108432/files) can be triggered by using the command: 
```
./op-readiness --provider=local --kubeconfig=/home/kubo/.kube/config --category activedirectory
```

close https://github.com/K8sbykeshed/op-readiness/issues/12