### PR TITLE
Adding --dry-run flag and fixing the Sonobuoy plugin

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,3 +22,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          args: -v

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,3 +25,4 @@ jobs:
         run: |
           touch e2e.test 
           make build
+          ./op-readiness --dry-run

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM golang:1.18 as build
-WORKDIR /go/src/github.com/k8sbykeshed/op-readiness
+WORKDIR /go/src/sigs.k8s.io/windows-operational-readiness
 COPY . .
-RUN curl -L "https://dl.k8s.io/v1.23.5/kubernetes-test-linux-amd64.tar.gz" -o /tmp/test.tar.gz
-RUN tar xvzf /tmp/test.tar.gz --strip-components=3 kubernetes/test/bin/e2e.test
+ARG KUBERNETES_VERSION
+RUN curl -L "https://dl.k8s.io/${KUBERNETES_VERSION}/kubernetes-test-linux-amd64.tar.gz" -o /tmp/test.tar.gz
+RUN tar xvzf /tmp/test.tar.gz --strip-components=3 kubernetes/test/bin/e2e.test && rm -f /tmp/test.tar.gz
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o op-readiness .
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates curl
+FROM debian:bookworm-slim
 WORKDIR /app
-COPY --from=0 /go/src/github.com/k8sbykeshed/op-readiness/e2e.test /app/
-COPY --from=0 /go/src/github.com/k8sbykeshed/op-readiness/op-readiness /app/
-COPY --from=0 /go/src/github.com/k8sbykeshed/op-readiness/tests.yaml /app/
+COPY --from=0 /go/src/sigs.k8s.io/windows-operational-readiness/e2e.test /app/
+COPY --from=0 /go/src/sigs.k8s.io/windows-operational-readiness/op-readiness /app/
+COPY --from=0 /go/src/sigs.k8s.io/windows-operational-readiness/tests.yaml /app/
 CMD ["./op-readiness"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Tests categories can be passed in the flag `--category`, this allows users to pi
 To run ALL tests do not pass the flag.
 
 ```
-./op-readiness --provider=local --kubeconfig=<path-to-kubeconfig> --category=Core.Network --category=networkpolicy
+./op-readiness --provider=local --kubeconfig=<path-to-kubeconfig> --category=Core.Network --category=Sub.NetworkPolicy
 
 Running Operational Readiness Test 1 / 10 : Ability to access Windows container IP by pod IP on Core.Network
 ...
@@ -51,7 +51,7 @@ We support an OCI image and a Sonobuoy plugin, so the user don't need to compile
 by default the latest version of the E2E binary is builtin the image, if you need to add a custom file
 just mount your local version in the plugin at `/app/e2e.test`.
 
-Before running sonobuoy, taint the windows worker node. Sonobuoy pod should be scheduled on the control plane node:
+Before running sonobuoy, taint the Windows worker node. Sonobuoy pod should be scheduled on the control plane node:
 
 ```
 kubectl taint node <windows-worker-node> sonobuoy:NoSchedule
@@ -73,23 +73,8 @@ The result can be found in the `./sonobuoy-results` folder.
 
 ##### Set a particular category
 
-It's possible to choose one or more categories of tests to run the plugin. In the following
-example both `core` and `activedirectory` tests are being use by the plugin.
-
-To allow all tests in the YAML don't use the `--category` flag.
-
-```
-spec:
-  command:
-    - /app/op-readiness
-  args:
-  - --category 
-  - core
-  - --category 
-  - activedirectory
-  - --test-file 
-  - tests.yaml
-````
+The `sonobuoy` folder has a [README](sonobuoy/README.md) detailing how to use the templates
+to render a custom `sonobuoy-plugin.yaml` file.
 
 ## Community, discussion, contribution, and support
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,7 @@ var (
 
 			for i, t := range opTestConfig.OpTestCases {
 				if !testCtx.CategoryEnabled(t.Category) {
-					zap.L().Warn(fmt.Sprintf("Skipping Operational Readiness Test %v / %v : %v is not in Category %v", i+1, len(opTestConfig.OpTestCases), t.Description, t.Category))
+					zap.L().Warn(fmt.Sprintf("[%s] %v / %v - Skipping Operational Readiness Test: %v", t.Category, i+1, len(opTestConfig.OpTestCases), t.Description))
 					continue
 				}
 

--- a/hack/kind_run.sh
+++ b/hack/kind_run.sh
@@ -1,3 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/pkg/testcases/cases.go
+++ b/pkg/testcases/cases.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"io"
 	"os/exec"
+	"strings"
 
 	"go.uber.org/zap"
 )
@@ -42,6 +43,13 @@ func (o *OpTestCase) RunTest(testCtx *TestContext) error {
 		"--node-os-distro", "windows",
 		"--non-blocking-taints", "os",
 		"--ginkgo.flakeAttempts", "1",
+	}
+
+	if testCtx.DryRun {
+		zap.L().Info("\t[DryRun] Testing with arguments",
+			zap.String("focus", strings.Join(o.Focus, " ")),
+			zap.String("skip", strings.Join(o.Skip, " ")))
+		return nil
 	}
 
 	if len(o.Focus) > 0 {

--- a/pkg/testcases/context.go
+++ b/pkg/testcases/context.go
@@ -29,16 +29,18 @@ type TestContext struct {
 	E2EBinary  string
 	KubeConfig string
 	Provider   string
+	DryRun     bool
 	TestConfig *OpTestConfig
 	Categories flags.ArrayFlags
 }
 
-func NewTestContext(e2ebinary, kubeconfig, provider string, testConfig *OpTestConfig, categories flags.ArrayFlags) *TestContext {
+func NewTestContext(e2ebinary, kubeconfig, provider string, testConfig *OpTestConfig, dryRun bool, categories flags.ArrayFlags) *TestContext {
 	return &TestContext{
 		E2EBinary:  e2ebinary,
 		KubeConfig: kubeconfig,
 		Provider:   provider,
 		TestConfig: testConfig,
+		DryRun:     dryRun,
 		Categories: categories,
 	}
 }

--- a/sonobuoy-plugin.yaml
+++ b/sonobuoy-plugin.yaml
@@ -4,13 +4,16 @@ sonobuoy-config:
   result-format: raw
 spec:
   command:
-    - /app/op-readiness
+  - /app/op-readiness
   args:
-    - --e2e-binary
-    - /app/e2e.test
-  image: knabben/op-readiness:dev
+  - --e2e-binary
+  - /app/e2e.test
+  - --category
+  - Core.Network
+  - --category
+  - Sub.NetworkPolicy
+  image: winopreadiness/op-readiness:dev
   name: plugin
-  resources: {}
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results

--- a/sonobuoy/README.md
+++ b/sonobuoy/README.md
@@ -1,0 +1,22 @@
+# Sonobouy Plugin configuration
+
+We use Carvel YTT to render the plugin YAML and patch the required fields. The user must change
+the `defaults.yaml` file and rerun `make sonobuoy-config-gen` to render the final `sonobouy-plugin.yaml` file.
+
+## Pre-requisites
+
+1. [Carvel YTT](https://carvel.dev/ytt)
+
+## Changing tests categories
+
+To enable Network and NetworkPolicy categories
+
+```yaml
+#@data/values
+---
+image: winopreadiness/op-readiness:dev
+dry-run: false
+category:
+- Core.Network
+- Sub.NetworkPolicy
+```

--- a/sonobuoy/defaults.yaml
+++ b/sonobuoy/defaults.yaml
@@ -1,0 +1,7 @@
+#@data/values
+---
+image: winopreadiness/op-readiness:dev
+dryrun: false
+category:
+- Core.Network
+- Sub.NetworkPolicy

--- a/sonobuoy/overlay.yaml
+++ b/sonobuoy/overlay.yaml
@@ -1,0 +1,23 @@
+#@ load("@ytt:data", "data")
+
+sonobuoy-config:
+  driver: Job
+  plugin-name: op-readiness
+  result-format: raw
+spec:
+  command:
+    - /app/op-readiness
+  args:
+    - --e2e-binary
+    - /app/e2e.test
+    #@ if/end data.values.dryrun:
+    - --dry-run
+    #@ for category in data.values.category:
+    - --category
+    - #@ category
+    #@ end
+  image: #@ data.values.image
+  name: plugin
+  volumeMounts:
+  - mountPath: /tmp/sonobuoy/results
+    name: results

--- a/tests.yaml
+++ b/tests.yaml
@@ -232,7 +232,7 @@ testCases:
   #   skip:
   #   - ''
   #   windows_image: .nan
-  - category: activedirectory
+  - category: Sub.ActiveDirectory
     description: Ability to read and write files as a GMSA User
     focus:
     - 'can read and write file to remote SMB folder'
@@ -240,7 +240,7 @@ testCases:
     skip:
     - ''
     windows_image: .nan
-  - category: activedirectory
+  - category: Sub.ActiveDirectory
     description: Ability to run a pod as a GMSA User and verify if it can connect to the domain successfully
     focus:
     - 'works end to end'
@@ -267,7 +267,7 @@ testCases:
   #   skip:
   #   - ''
   #   windows_image: .nan
-  - category: networkpolicy
+  - category: Sub.NetworkPolicy
     description: Ability to protect IPv4 pods from acceessing other pods when TCP NetworkPolicys
       are present that block specific pod connectivity.
     focus:
@@ -276,7 +276,7 @@ testCases:
     skip:
     - ''
     windows_image: .nan
-  - category: networkpolicy
+  - category: Sub.NetworkPolicy
     description: Ability to protect IPv4 pods from acceessing other pods when TCP NetworkPolicys
       are present that block specific namespace connectibity.
     focus:

--- a/tests.yaml
+++ b/tests.yaml
@@ -1,8 +1,10 @@
 kubernetesVersions:
+- 1.25
+- 1.24
 - 1.23
-- 1.22
 
 testCases:
+  # Network category
   - category: Core.Network
     description: Ability to access Windows container IP by pod IP
     focus:
@@ -269,7 +271,7 @@ testCases:
     description: Ability to protect IPv4 pods from acceessing other pods when TCP NetworkPolicys
       are present that block specific pod connectivity.
     focus:
-    - 'sdfadf'
+    - 'test'
     linux_image: .nan
     skip:
     - ''


### PR DESCRIPTION
- Adding dry run as a way to support general and e2e testing
- Moving to dockerhub.io winopreadiness
- Fixing the sonobuoy plugin Dockerfile and template rendering

Blocked by https://github.com/kubernetes-sigs/windows-operational-readiness/pull/20