### PR TITLE
Fix report on Sonobuoy plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as build
+FROM golang:1.19 as build
 WORKDIR /go/src/sigs.k8s.io/windows-operational-readiness
 COPY . .
 ARG KUBERNETES_VERSION
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o op-readiness .
 
 FROM debian:bookworm-slim
 WORKDIR /app
-COPY --from=0 /go/src/sigs.k8s.io/windows-operational-readiness/run.sh /app/
+ENV ARTIFACTS /tmp/sonobuoy/results
 COPY --from=0 /go/src/sigs.k8s.io/windows-operational-readiness/e2e.test /app/
 COPY --from=0 /go/src/sigs.k8s.io/windows-operational-readiness/op-readiness /app/
 COPY --from=0 /go/src/sigs.k8s.io/windows-operational-readiness/tests.yaml /app/

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ SHELL := /usr/bin/env bash
 # Container build
 STAGING_REGISTRY ?= gcr.io/k8s-staging-win-op-rdnss
 IMG_NAME ?= k8s-win-op-rdnss
-TAG ?=  $(shell git describe --tags --always `git rev-parse HEAD`)
+TAG ?= $(shell git describe --tags --always `git rev-parse HEAD`)
 IMG_PATH ?= $(STAGING_REGISTRY)/$(IMG_NAME)
 
 # Kubernetes version
@@ -86,14 +86,13 @@ local-kind-test: image_build ## Run e2e tests with Kind, useful for development 
 
 .PHONY: sonobuoy-plugin
 sonobuoy-plugin:  ## Run the Sonobuoy plugin
-	sonobuoy delete
-	sonobuoy run --sonobuoy-image projects.registry.vmware.com/sonobuoy/sonobuoy:v0.56.9 --plugin sonobuoy-plugin.yaml --wait=0
+	sonobuoy delete --all
+	sonobuoy run --sonobuoy-image projects.registry.vmware.com/sonobuoy/sonobuoy:v0.56.9 --plugin sonobuoy-plugin.yaml --wait
 
 .PHONY: sonobuoy-results
 sonobuoy-results:  ## Read Sonobuoy results
-	rm -rf sonobuoy-results && mkdir sonobuoy-results
 	$(eval OUTPUT=$(shell sonobuoy retrieve))
-	tar -xf $(OUTPUT) -C sonobuoy-results && rm -f $(OUTPUT) && cat sonobuoy-results/plugins/op-readiness/results/global/out.json
+	sonobuoy results --mode=report $(OUTPUT)
 
 .PHONY: sonobuoy-config-gen
 sonobuoy-config-gen:  ## Run the Sonobuoy plugin

--- a/README.md
+++ b/README.md
@@ -69,7 +69,48 @@ To retrieve the sonobuoy result:
 make sonobuoy-results
 ```
 
-The result can be found in the `./sonobuoy-results` folder.
+The failed results are going to be formatted as follow by default:
+
+````
+Plugin: op-readiness
+Status: failed
+Total: 6965
+Passed: 0
+Failed: 1
+Skipped: 6964
+
+Failed tests:
+[sig-network] Netpol NetworkPolicy between server and client should deny ingress from pods on other nam
+espaces [Feature:NetworkPolicy]
+
+Run Details:
+API Server version: v1.24.0
+Node health: 1/1 (100%)
+Pods health: 12/20 (60%)
+Details for failed pods:
+netpol-2630-x/a Ready:: :
+netpol-2630-x/c Ready:: :
+netpol-2630-y/a Ready:: :
+netpol-2630-y/b Ready:: :
+netpol-2630-y/c Ready:: :
+netpol-2630-z/a Ready:: :
+netpol-2630-z/b Ready:: :
+netpol-2630-z/c Ready:: :
+Errors detected in files:
+Errors:
+84 podlogs/kube-system/kube-controller-manager-kind-control-plane/logs/kube-controller-manager.txt
+51 podlogs/kube-system/kube-scheduler-kind-control-plane/logs/kube-scheduler.txt
+47 podlogs/kube-system/kube-apiserver-kind-control-plane/logs/kube-apiserver.txt
+10 podlogs/sonobuoy/sonobuoy-op-readiness-job-45e7d10ce5584b90/logs/plugin.txt
+ 6 podlogs/kube-system/kube-proxy-jdx82/logs/kube-proxy.txt
+Warnings:
+30 podlogs/kube-system/kube-scheduler-kind-control-plane/logs/kube-scheduler.txt
+22 podlogs/kube-system/kube-apiserver-kind-control-plane/logs/kube-apiserver.txt
+ 7 podlogs/kube-system/kube-controller-manager-kind-control-plane/logs/kube-controller-manager.txt
+ 2 podlogs/sonobuoy/sonobuoy/logs/kube-sonobuoy.txt
+ 1 podlogs/kube-system/etcd-kind-control-plane/logs/etcd.txt
+ 1 podlogs/sonobuoy/sonobuoy-op-readiness-job-45e7d10ce5584b90/logs/plugin.txt
+```
 
 ##### Set a particular category
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,7 +63,6 @@ var (
 				os.Exit(1)
 			}
 			testCtx := testcases.NewTestContext(E2EBinary, kubeConfig, provider, opTestConfig, dryRun, reportDir, categories)
-			failedTest := false
 
 			for idx, t := range opTestConfig.OpTestCases {
 				if !testCtx.CategoryEnabled(t.Category) {
@@ -74,12 +73,7 @@ var (
 				zap.L().Info(fmt.Sprintf("[%s] %v / %v - Running Operational Readiness Test: %v", t.Category, idx+1, len(opTestConfig.OpTestCases), t.Description))
 				if err = t.RunTest(testCtx, idx+1); err != nil {
 					zap.L().Error(fmt.Sprintf("Operational Readiness Test %v failed, error is %v", t.Description, zap.Error(err)))
-					failedTest = true
 				}
-			}
-
-			if failedTest {
-				os.Exit(1)
 			}
 		},
 	}

--- a/sonobuoy-plugin.yaml
+++ b/sonobuoy-plugin.yaml
@@ -1,15 +1,13 @@
 sonobuoy-config:
   driver: Job
   plugin-name: op-readiness
-  result-format: manual
+  result-format: junit
 spec:
   command:
-  - /app/run.sh
+  - /app/op-readiness
   args:
   - --e2e-binary
   - /app/e2e.test
-  - --category
-  - Core.Network
   - --category
   - Extend.NetworkPolicy
   image: gcr.io/k8s-staging-win-op-rdnss/k8s-win-op-rdnss:latest

--- a/tests.yaml
+++ b/tests.yaml
@@ -272,7 +272,7 @@ testCases:
   #   - ''
   #   windows_image: .nan
   # - category: Extend.NetworkPolicy
-  #   description: Ability to protect IPv4 pods from acceessing other pods when TCP NetworkPolicys
+  #   description: Ability to protect IPv4 pods from accessing other pods when TCP NetworkPolicys
   #     are present that block specific pod connectivity.
   #   focus:
   #   - ''
@@ -281,8 +281,8 @@ testCases:
   #   - ''
   #   windows_image: .nan
   - category: Extend.NetworkPolicy
-    description: Ability to protect IPv4 pods from acceessing other pods when TCP NetworkPolicys
-      are present that block specific namespace connectibity.
+    description: Ability to protect IPv4 pods from accessing other pods when TCP NetworkPolicys
+      are present that block specific namespace connectability.
     focus:
     - 'should deny ingress from pods on other namespaces'
     linux_image: .nan


### PR DESCRIPTION
Fixes #https://github.com/kubernetes-sigs/windows-operational-readiness/issues/23

Uses Junit to report errors

```
❯ sonobuoy results --mode=report $(sonobuoy retrieve)
Plugin: op-readiness
Status: failed
Total: 6965
Passed: 0
Failed: 1
Skipped: 6964

Failed tests:
[sig-network] Netpol NetworkPolicy between server and client should deny ingress from pods on other nam
espaces [Feature:NetworkPolicy]

Run Details:
API Server version: v1.24.0
Node health: 1/1 (100%)
Pods health: 12/20 (60%)
Details for failed pods:
netpol-2630-x/a Ready:: :
netpol-2630-x/c Ready:: :
netpol-2630-y/a Ready:: :
netpol-2630-y/b Ready:: :
netpol-2630-y/c Ready:: :
netpol-2630-z/a Ready:: :
netpol-2630-z/b Ready:: :
netpol-2630-z/c Ready:: :
Errors detected in files:
Errors:
84 podlogs/kube-system/kube-controller-manager-kind-control-plane/logs/kube-controller-manager.txt
51 podlogs/kube-system/kube-scheduler-kind-control-plane/logs/kube-scheduler.txt
47 podlogs/kube-system/kube-apiserver-kind-control-plane/logs/kube-apiserver.txt
10 podlogs/sonobuoy/sonobuoy-op-readiness-job-45e7d10ce5584b90/logs/plugin.txt
 6 podlogs/kube-system/kube-proxy-jdx82/logs/kube-proxy.txt
Warnings:
30 podlogs/kube-system/kube-scheduler-kind-control-plane/logs/kube-scheduler.txt
22 podlogs/kube-system/kube-apiserver-kind-control-plane/logs/kube-apiserver.txt
 7 podlogs/kube-system/kube-controller-manager-kind-control-plane/logs/kube-controller-manager.txt
 2 podlogs/sonobuoy/sonobuoy/logs/kube-sonobuoy.txt
 1 podlogs/kube-system/etcd-kind-control-plane/logs/etcd.txt
 1 podlogs/sonobuoy/sonobuoy-op-readiness-job-45e7d10ce5584b90/logs/plugin.txt
```