### PR TITLE
Chore: Added `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github
+*.md
+OWNERS


### PR DESCRIPTION
**What this PR does / why we need it**:

- This PR will add a `.dockerignore` file. We need it to reduce the docker image build size and make the build faster


