### PR TITLE
Remove extra character from README `5`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Define an operational readiness standard for Kubernetes clusters supporting Wind
 Related KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-windows/2578-windows-conformance
 
 ## Build the project
-5
+
 #### Build the project with the default Kubernetes version (e.g. v1.25.0)
 
 ```shell


### PR DESCRIPTION
### Chnages

Remove the extra Character `5`.

### Screenshot

![Screenshot from 2022-10-28 21-10-36](https://user-images.githubusercontent.com/51878265/198678052-7af195d1-4a6d-4b21-b9ba-64ddfb6fe4d4.png)

Really sorry, by mistake I added that extra `5`

