### PR TITLE
Add GitHub issue and Pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,17 @@
+name: Bug Report
+description: Report a bug encountered
+labels: kind/bug
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the bug. What is the current and expected behaviour?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce it (as minimally and precisely as possible)?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -1,0 +1,17 @@
+name: New Feature or Enhancement
+description: Provide details for a new feature or enhancement to be developed
+labels: kind/feature
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+#### What type of PR is this?
+
+#### What this PR does / why we need it:
+
+#### Which issue(s) this PR fixes:


### PR DESCRIPTION
#### What type of PR is this?
- New feature

#### What this PR does / why we need it:
- To standardize Github issues and pull requests

#### Which issue(s) this PR fixes:
- https://github.com/kubernetes-sigs/windows-operational-readiness/issues/62