### PR TITLE
Fix `make clean` as `--report-prefix/` is recognized as option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ lint-go: ## Lint codebase
 
 .PHONY: clean
 clean :
-	rm -rf op-readiness test.tar.gz e2e.test --report-prefix/
+	rm -rf op-readiness test.tar.gz e2e.test ./--report-prefix/
 
 ## --------------------------------------
 ## Build


### PR DESCRIPTION
When running `make clean`, it failed with the following error:
```
rm: unrecognized option '--report-prefix/'
Try 'rm ./--report-prefix/' to remove the file ‘--report-prefix/’.
Try 'rm --help' for more information.
make: *** [clean] Error 1
```

#### What type of PR is this?
Bug fix

#### What this PR does / why we need it:
It fixes `make clean` in repo

#### Which issue(s) this PR fixes: