### PR TITLE
Add ginkgo verbose logging for e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ You can specify the following arguments as part of the command to run the tests.
 | `--provider`   | The name of the Kubernetes provider (e.g. aks, gke, aws, local, skeleton)                                                                         | `local`                                        |
 | `--report-dir` | Path to where to dump the JUnit test report.                                                                                                      | Uses location set to `ARTIFACTS` env variable  |  
 | `--dry-run`    | Do not run actual tests, used for sanity check.                                                                                                   | `false`                                        |
+| `--verbose`    | Enable Ginkgo verbosity.                                                                                                                          | `false`                                        |
 | `--category`   | Specify a category with tests you want to run. You can specify multiple categories e.g. `--category=Core.Network --category=Extend.NetworkPolicy` | Empty, will run all tests.                     |
 
 ### Run the tests as a Sonobuoy plugin

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ var (
 	testFile   string
 	kubeConfig string
 	dryRun     bool
+	verbose    bool
 	reportDir  string
 	categories flags.ArrayFlags
 
@@ -63,7 +64,7 @@ var (
 				zap.L().Error(fmt.Sprintf("Create op-readiness context failed, error is %v", zap.Error(err)))
 				os.Exit(1)
 			}
-			testCtx := testcases.NewTestContext(E2EBinary, kubeConfig, provider, opTestConfig, dryRun, reportDir, categories)
+			testCtx := testcases.NewTestContext(E2EBinary, kubeConfig, provider, opTestConfig, dryRun, verbose, reportDir, categories)
 
 			for idx, t := range opTestConfig.OpTestCases {
 				if !testCtx.CategoryEnabled(t.Category) {
@@ -98,5 +99,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&kubeConfig, clientcmd.RecommendedConfigPathFlag, os.Getenv(clientcmd.RecommendedConfigPathEnvVar), "Path to kubeconfig containing embedded authinfo.")
 	rootCmd.PersistentFlags().StringVar(&reportDir, "report-dir", getEnvOrDefault("ARTIFACTS", ""), "Report dump directory, uses artifact for CI integration when set.")
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "Do not run actual tests, used for sanity check.")
+	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "Enable Ginkgo verbosity.")
 	rootCmd.PersistentFlags().Var(&categories, "category", "Append category of tests you want to run, default empty will run all tests.")
 }

--- a/pkg/testcases/cases.go
+++ b/pkg/testcases/cases.go
@@ -19,6 +19,7 @@ package testcases
 import (
 	"bufio"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -75,6 +76,11 @@ func (o *OpTestCase) RunTest(testCtx *TestContext, idx int) error {
 		}
 		args = append(args, "--ginkgo.skip")
 		args = append(args, skip)
+	}
+
+	if testCtx.Verbose {
+		args = append(args, "--ginkgo.v")
+		args = append(args, "--ginkgo.trace")
 	}
 
 	cmd := exec.Command(testCtx.E2EBinary, args...)


### PR DESCRIPTION
Added a --verbose flag when true will enable verbosity for ginkgo

#### What type of PR is this?
Improvement

#### What this PR does / why we need it:
Added a verbose flag, this helps debugging of failing tests.

#### Which issue(s) this PR fixes:
#75 