### PR TITLE
Fix previous commit causing unit test failures

### DIFF
--- a/pkg/testcases/cases.go
+++ b/pkg/testcases/cases.go
@@ -19,7 +19,6 @@ package testcases
 import (
 	"bufio"
 	"encoding/xml"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"

--- a/pkg/testcases/context.go
+++ b/pkg/testcases/context.go
@@ -30,18 +30,20 @@ type TestContext struct {
 	KubeConfig string
 	Provider   string
 	DryRun     bool
+	Verbose    bool
 	ReportDir  string
 	TestConfig *OpTestConfig
 	Categories flags.ArrayFlags
 }
 
-func NewTestContext(e2ebinary, kubeconfig, provider string, testConfig *OpTestConfig, dryRun bool, reportDir string, categories flags.ArrayFlags) *TestContext {
+func NewTestContext(e2ebinary, kubeconfig, provider string, testConfig *OpTestConfig, dryRun bool, verbose bool, reportDir string, categories flags.ArrayFlags) *TestContext {
 	return &TestContext{
 		E2EBinary:  e2ebinary,
 		KubeConfig: kubeconfig,
 		Provider:   provider,
 		TestConfig: testConfig,
 		DryRun:     dryRun,
+		Verbose:    verbose,
 		ReportDir:  reportDir,
 		Categories: categories,
 	}


### PR DESCRIPTION
1. Removed `fmt` import from cases.go
2. Added Verbose field to TestContext struct

#### What type of PR is this?
fixes a bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes: