### PR TITLE
Resolve lint errors causing CI to break

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,8 +3,6 @@ linters:
   enable:
   - asciicheck
   - bodyclose
-  - deadcode
-  - depguard
   - dogsled
   - errcheck
   - exportloopref
@@ -19,7 +17,6 @@ linters:
   - gosec
   - gosimple
   - govet
-  - ifshort
   - importas
   - ineffassign
   - misspell
@@ -32,16 +29,15 @@ linters:
   - revive
   - rowserrcheck
   - staticcheck
-  - structcheck
   - stylecheck
   - thelper
   - typecheck
   - unconvert
   - unparam
   - unused
-  - varcheck
   - whitespace
-
+disable:
+  - depguard # Disabling because it is causing CI to break. See issue https://github.com/golangci/golangci-lint/issues/3906 fore more
 run:
   skip-files:
   - "kubernetes/.*"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/tools/clientcmd"
-
 	"sigs.k8s.io/windows-operational-readiness/pkg/flags"
 	"sigs.k8s.io/windows-operational-readiness/pkg/testcases"
 )

--- a/pkg/testcases/cases.go
+++ b/pkg/testcases/cases.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 
 	"go.uber.org/zap"
-
 	"sigs.k8s.io/windows-operational-readiness/pkg/report"
 )
 
@@ -167,10 +166,8 @@ func CleanupJUnitXML(path string) error {
 	if cleanContent, err = xml.MarshalIndent(testSuites, "  ", "    "); err != nil {
 		return err
 	}
-	if err = writeFileContent(path, cleanContent); err != nil {
-		return err
-	}
-	return nil
+
+	return writeFileContent(path, cleanContent)
 }
 
 // writeFileContent save the content to a file.

--- a/pkg/testcases/context.go
+++ b/pkg/testcases/context.go
@@ -24,7 +24,6 @@ import (
 
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
-
 	"sigs.k8s.io/windows-operational-readiness/pkg/flags"
 )
 
@@ -101,7 +100,7 @@ func getTestFiles(testDirectory string) ([]string, error) {
 			return nil, err
 		}
 
-		testDirectory = testDirectory + "/specifications/"
+		testDirectory += "/specifications/"
 	}
 
 	testFiles := make([]string, 0)

--- a/pkg/testcases/validation.go
+++ b/pkg/testcases/validation.go
@@ -17,8 +17,6 @@ limitations under the License.
 package testcases
 
 import (
-	"fmt"
-
 	"github.com/go-playground/validator/v10"
 	"go.uber.org/zap"
 )
@@ -27,17 +25,14 @@ import (
 func (s *Specification) validateYAML() error {
 	validate := validator.New()
 	validate.RegisterStructValidation(SpecificationValidation, Specification{})
-	if err := validate.Struct(s); err != nil {
-		return err
-	}
-	return nil
+	return validate.Struct(s)
 }
 
 // SpecificationValidation set the required fields and is used by the validator function.
 func SpecificationValidation(sl validator.StructLevel) {
 	specification := sl.Current().Interface().(Specification)
 	if specification.Category == "" {
-		zap.L().Error(fmt.Sprintf("Category Required"))
+		zap.L().Error("Category Required")
 		sl.ReportError(specification.Category, "category", "Category", "categoryRequired", "")
 	}
 	for _, testCase := range specification.TestCases {


### PR DESCRIPTION
#### What type of PR is this?
Cleanup

#### What this PR does / why we need it:
It resolves lint errors causing new PRs to fail lint checks.

Changes are 
- making minor changes to resolve lint errors e.g. unnecessary use of fmt.Sprintf
- removing linters which are no longer actively maintained
- disabling depguard as a linter

See additinoal info section for more regarding why the below changes were made


#### Which issue(s) this PR fixes:
https://github.com/kubernetes-sigs/windows-operational-readiness/issues/78

#### Additional info
Lint errors are failing with the following errors. See example failing Github Actions in PR https://github.com/kubernetes-sigs/windows-operational-readiness/pull/81
```
pkg/testcases/context_test.go:22:2: import 'sigs.k8s.io/windows-operational-readiness/pkg/flags' is not allowed from list 'Main' (depguard)
        "sigs.k8s.io/windows-operational-readiness/pkg/flags"
```
 
To resolve the above errors, I disabled depguard because it has a known breaking issue. See https://github.com/golangci/golangci-lint/issues/3906 fore more. For the meantime, we will simply remove the dependency until the issue is resolved. In summary, lint checks are failing because depguard used to allow all dependencies by default, but its v2 release inverts that logic to deny by default. We do not have control over the allow list because it is abstracted by golangci-lint

Other changes include removing linters which are no longer actively maintained
```
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
WARN [runner] The linter 'ifshort' is deprecated (since v1.48.0) due to: The repository of the linter has been deprecated by the owner. 

```