### PR TITLE
Update test cases for Core.Scheduling and Core.Concurrent

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,9 +80,12 @@ var (
 					zap.L().Info(fmt.Sprintf("[%s] No Operational Readiness tests to run", string(s.Category)))
 				} else {
 					for tIdx, t := range s.TestCases {
-						zap.L().Info(fmt.Sprintf("[%s] %v / %v Tests - Running Operational Readiness test: %v", s.Category, tIdx+1, len(s.TestCases), t.Description))
+						logPrefix := fmt.Sprintf("[%s] %v / %v Tests - ", s.Category, tIdx+1, len(s.TestCases))
+						zap.L().Info(fmt.Sprintf("%sRunning Operational Readiness Test: %v", logPrefix, t.Description))
 						if err = t.RunTest(testCtx, tIdx+1); err != nil {
-							zap.L().Error(fmt.Sprintf("Operational Readiness Test %v failed, error is %v", t.Description, zap.Error(err)))
+							zap.L().Error(fmt.Sprintf("%sFailed Operational Readiness Test: %v, error is %v", logPrefix, t.Description, zap.Error(err)))
+						} else {
+							zap.L().Info(fmt.Sprintf("%sPassed Operational Readiness Test: %v", logPrefix, t.Description))
 						}
 					}
 				}

--- a/specifications/core-concurrent/spec.yaml
+++ b/specifications/core-concurrent/spec.yaml
@@ -16,3 +16,8 @@ testCases:
 #   - ''
 #   skip:
 #   - ''
+ - description: Ability to schedule 10 pods concurrently
+   focus:
+   - '\[Feature\:Windows\] Density'
+   skip:
+   - ''

--- a/specifications/core-scheduling/spec.yaml
+++ b/specifications/core-scheduling/spec.yaml
@@ -1,12 +1,28 @@
 category: Core.Scheduling
 testCases:
-# - description: Ability to schedule pods with CPU and Memory limits demonstrably honored over time.
-#   focus:
-#   - ''
-#   skip:
-#   - ''
-# - description: Ability to demonstrate the pods requesting more CPU and Memory then available are left in the Pending state over time.
-#   focus:
-#   - ''
-#   skip:
-#   - ''
+#  These test(s) is commented out because it requires a pod node selector set on the kubernetes test
+#  - description: Ability to create and update a limit range and ensure that pods adhere to specified Limitranges
+#    focus:
+#      - 'should create a LimitRange with defaults and ensure pod has those defaults applied'
+#    skip:
+#      - ''
+#  - description: Ability to demonstrate the pods requesting more CPU and Memory then available are left in the Pending state over time.
+#    focus:
+#      - 'verify pod overhead is accounted for'
+#    skip:
+#      - ''
+#  - description: Ability to preempt a lower priority pod in favor of scheduling higher priority pod
+#    focus:
+#      - 'validates basic preemption works'
+#    skip:
+#      - ''
+  - description: Ability to not exceed pod memory limits and should fail once there isn't enough memory
+    focus:
+      - '\[Feature\:Windows\] Memory Limits'
+    skip:
+      - ''
+  - description: Ability to not exceed pod CPU limits
+    focus:
+      - '\[Feature\:Windows\] Cpu Resources'
+    skip:
+      - ''


### PR DESCRIPTION
## What this PR does / why we need it:
PR has the following changes for respective categories.

`Core.Scheduling` category
- Adds new test cases that cover requirements in the [KEP](https://github.com/knabben/enhancements/blob/3ee6784895d650caa99e3ad23a361465478effb5/keps/sig-windows/2578-windows-conformance/README.md)
- References Kubernetes upstream tests that cover existing items in the [KEP](https://github.com/knabben/enhancements/blob/3ee6784895d650caa99e3ad23a361465478effb5/keps/sig-windows/2578-windows-conformance/README.md).

`Core.Concurrency` category
- Adds a new test case that covers one of the requirements in the [KEP](https://github.com/knabben/enhancements/blob/3ee6784895d650caa99e3ad23a361465478effb5/keps/sig-windows/2578-windows-conformance/README.md)

## Additional comments
- Commented out issues for `Core.Scheduling` will need to have upstream Kubernetes tests updated to resolve issue whereby pods are not scheduled on Windows nodes successfully, we need to add a pod node selector.
- Other changes include a new log statement to print out statement regarding successs when a test has passed

## Which issue(s) this PR fixes:
- https://github.com/kubernetes-sigs/windows-operational-readiness/issues/73
- https://github.com/kubernetes-sigs/windows-operational-readiness/issues/67