### PR TITLE
Add instrunctions to specify why and how to implement mutating webhook to schedule on Windows nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * [Windows Operational Readiness](#windows-operational-readiness)
     * [Build the project](#build-the-project)
     * [Run the tests](#run-the-tests)
+        * [Preliminaries](#preliminaries)
         * [Run the tests using the ops-readiness binary](#run-the-tests-using-the-ops-readiness-binary)
         * [Run the tests as a Sonobuoy plugin](#run-the-tests-as-a-sonobuoy-plugin)
         * [Running on CAPZ upstream](#running-on-capz-upstream)
@@ -69,9 +70,27 @@ The following categories exist.
 
 You can run the tests in the following ways.
 
-### Run the tests using the ops-readiness binary
+### Preliminaries
+1. Build the project 
+   - Before running the tests, ensure you have built the project using the previously specified instrunctions regarding how
+to [build the project](#build-the-project).
+2. Implement a webhook to ensure tests are exclusively scheduled on Windows nodes.
+   - For you to reliably target all the Kubernetes e2e tests to be scheduled on a Windows node, you will need to 
+set up a [mutating webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
+which dynamically adds a `kubernetes.io/os:windows` pod selector to every scheduled pod.
+[`kubernetes.io/os`](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-os) is a well-known
+label which is used to indicate the operating system for the node, so that it can be taken into account by the _kubelet_
+and by the _kube-scheduler_.
+   - The reason it is necessary to add the webhook is to ensure appropriate and successful scheduling of pods on Windows
+     nodes while running the `ops-readiness` tests. Incorrectly scheduling the pods on a different operating system may
+     result in false positives or false negatives in the test results. Some Kubernetes e2e tests do not specify a pod
+     selector and therefore there can be no guarantee that the pods will be scheduled on Windows node when running
+     the `ops-readiness` tests. To reliably run the operational readiness tests on Windows nodes, it is required to
+     configure such a webhook.
+   - To set up your webhook, you can write your own webhook, or repurpose the one provided in this project.
+     See the [webhook README](webhook/README.md) for more instrunctions on how to use the webhook provided in this project.
 
-Before running the tests, ensure you have built the project using hte previously specified instrunctions.
+### Run the tests using the ops-readiness binary
 
 You can run the tests using the following command. This example command will run all the tests in the op-readiness test
 suite.

--- a/webhook/README.md
+++ b/webhook/README.md
@@ -1,0 +1,75 @@
+## Setting up a Windows pod selector webhook
+
+This document describes the steps to set up a mutating webhook to ensure successful scheduling of pods on a Windows
+node. It achieves this by adding a `kubernetes.io/os: windows` key value node selector for each pod. The following steps
+are derived based on the webhook maintained by the
+Kubernetes [`sig-windows`](https://github.com/kubernetes/community/tree/master/sig-windows) team. For reference,
+see [HyperV testing README](https://github.com/kubernetes-sigs/windows-testing/blob/master/helpers/hyper-v-mutating-webhook/README.md).
+
+Steps
+
+1. Create your cluster and ensure the cluster has at least one Windows node to test
+2. Create a TLS certificate for secure communication
+    - The Kubernetes API server uses HTTPS to communicate with webhooks. To support HTTPS, add a TLS certificate.
+      You can either import an existing one from an externally trusted Certificate Authority (CA), or create your own
+      using the following script and save the CA bundle for the next section.
+
+```
+./generate-cert.sh
+```
+
+3. Update the `caBundle` in `deployment.yaml` with the CA bundle you created the last step e.g.
+
+```
+...
+   caBundle: |
+     LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURMekNDQWhlZ0F3SUJBZ0lVUnBOMHU0c3NqbFV5
+     ...
+     LS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+...
+```
+
+4. Update handler name in `runtimeclass.yaml` with the appropriate handler name for your container runtime e.g.
+
+```
+...
+handler: runhcs-wcow-process
+...
+```
+
+5. Run the `setup.sh` script to apply the YAML manifests. The script performs various actions including
+    - taint the Windows nodes to ensure only pods with tolerations can schedule on a Windows node
+    - store the TLS certificate and its corresponding private key as a secret
+
+5. Run the `setup.sh` script to apply the YAML manifests. The script performs various actions including
+    - taint the Windows nodes to ensure only pods with tolerations can schedule on a Windows node
+    - store the TLS certificate and its corresponding private key as a secret
+    - installing cert manager
+    - installing the webhook
+
+6. Verify that the webhook is correctly running
+    - You should see the `windows-webhook-controller-manager deployment` in a running state
+
+```
+kubect get pods -n windows-webhook-system
+```
+
+7. Test if the webhook is working by deploying a pod without a node selector
+    - Verify if the webhook took effect correctly by checking the logs. You should see a 200 code response with a log
+      such as the following
+   ```
+   ...
+   2023-10-24T06:29:00Z	INFO	webhook	Pod win-webserver-2019-56f7d48b87-ncmlz is being mutated
+   2023-10-24T06:29:00Z	DEBUG	controller-runtime.webhook.webhooks	wrote response	{"webhook": "/mutate-v1-pod", "code": 200, "reason": "", "UID": "0c6a07f2-71a0-4d6d-a756-e75704da4d3e", "allowed": true}
+   ...
+   ```
+    - Describe the pod to see if the node selector is automatically updated to the following
+   ```
+   ...
+   Node-Selectors:   kubernetes.io/arch=amd64
+                     kubernetes.io/os=windows
+   ...
+   ```
+8. After verifying that the webhook is running and testing if the webhook is correctly taking effect, you are ready to
+   begin running the Ops Readiness Windows focused test suite, with confidence that all pods will be correctly scheduled
+   on a Windows node.

--- a/webhook/deployment.yaml
+++ b/webhook/deployment.yaml
@@ -1,0 +1,442 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: windows-webhook
+  name: windows-webhook-controller-manager
+  namespace: windows-webhook-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: role
+    app.kubernetes.io/part-of: windows-webhook
+  name: windows-webhook-leader-election-role
+  namespace: windows-webhook-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: windows-webhook-manager-role
+rules:
+- apiGroups:
+  - windows.windows.k8s.io
+  resources:
+  - hypervs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - windows.windows.k8s.io
+  resources:
+  - hypervs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - windows.windows.k8s.io
+  resources:
+  - hypervs/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: windows-webhook
+  name: windows-webhook-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: proxy-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: windows-webhook
+  name: windows-webhook-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: windows-webhook
+  name: windows-webhook-leader-election-rolebinding
+  namespace: windows-webhook-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: windows-webhook-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: windows-webhook-controller-manager
+  namespace: windows-webhook-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: windows-webhook
+  name: windows-webhook-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: windows-webhook-manager-role
+subjects:
+- kind: ServiceAccount
+  name: windows-webhook-controller-manager
+  namespace: windows-webhook-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: proxy-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: windows-webhook
+  name: windows-webhook-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: windows-webhook-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: windows-webhook-controller-manager
+  namespace: windows-webhook-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: windows-webhook
+    control-plane: controller-manager
+  name: windows-webhook-controller-manager-metrics-service
+  namespace: windows-webhook-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: hyperv
+    app.kubernetes.io/part-of: windows-webhook
+  name: windows-webhook-webhook-service
+  namespace: windows-webhook-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/part-of: windows-webhook
+    control-plane: controller-manager
+  name: windows-webhook-controller-manager
+  namespace: windows-webhook-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+                - ppc64le
+                - s390x
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /manager
+        image: sigwindowstools/hyperv-runtimeclass-mutating-webhook:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: windows-webhook-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: serving-cert
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: certificate
+    app.kubernetes.io/part-of: windows-webhook
+  name: windows-webhook-serving-cert
+  namespace: windows-webhook-system
+spec:
+  dnsNames:
+  - windows-webhook-webhook-service.windows-webhook-system.svc
+  - windows-webhook-webhook-service.windows-webhook-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: windows-webhook-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/component: certificate
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: selfsigned-issuer
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: issuer
+    app.kubernetes.io/part-of: windows-webhook
+  name: windows-webhook-selfsigned-issuer
+  namespace: windows-webhook-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: windows-webhook-system/windows-webhook-serving-cert
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: mutating-webhook-configuration
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: mutatingwebhookconfiguration
+    app.kubernetes.io/part-of: windows-webhook
+  name: windows-webhook-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: windows-webhook-webhook-service
+      namespace: windows-webhook-system
+      path: /mutate-v1-pod
+    caBundle: |
+      LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURMekNDQWhlZ0F3SUJBZ0lVUnBOMHU0c3NqbFV5
+      OUxHMFlaWnAxdXdLczVrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0p6RUxNQWtHQTFVRUJoTUNRVlV4R0RB
+      V0JnTlZCQU1NRDNkcGJtUnZkM010ZDJWaWFHOXZhekFlRncweQpNekV3TWpRd05qQTJNVFZhRncweU5E
+      RXdNak13TmpBMk1UVmFNQ2N4Q3pBSkJnTlZCQVlUQWtGVk1SZ3dGZ1lEClZRUUREQTkzYVc1a2IzZHpM
+      WGRsWW1odmIyc3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUsKQW9JQkFRQ25jcm9M
+      S1ViZ3k5U2hVYkNMZTBDQXZKcFBreTE0L3pSWWh3ZlVjdGRadGY5aEt0MkYvL1BtL1AvLwpxRHRnYzR4
+      YlRPZnY3bWd6Rk56MTlJbzY1dHBuQmpmSmNNbm1iUzNTQ0VqUXdheTBMQ2hocUtyTlp0K0duY29oClB5
+      NDArRG5nZm9SamFxTmdLT2xPL1hYNzRZTDFBdWw1SkVLTnFZSVlaRVpEaTRWVmxUWGsyL0xrdUhFYmJl
+      ME4KR25MNDlvQzhsczFUTVhDcDBISkgwOGpUZDZFVm04WWZDYUNTemZwYkZuNUNBMVdyN0ZvZjhRQjJq
+      STJlZUlPVgpNeGxOcm1WOFRMTGFxeHlyWmthbUN6YVlpdGRQSVlocnZsUVYvTERtNGJRYU8rZ21mTnY3
+      SzhDWXJ5eVBVaUFQCkxLMXErV0tkVzM0b0lzWUoyVFVsbjA4NW9vUGZBZ01CQUFHalV6QlJNQjBHQTFV
+      ZERnUVdCQlFZeEVsQjFwQzAKd3d4THdLSTd4eTZReGNGNEpUQWZCZ05WSFNNRUdEQVdnQlFZeEVsQjFw
+      QzB3d3hMd0tJN3h5NlF4Y0Y0SlRBUApCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJD
+      d1VBQTRJQkFRQm9wMWdwRCtWQzNqdTlKVWhTCkI0WTFzWFljeXhEOHJJdHJ6R0VDSDlGSzB0WlJNU2ZC
+      OThWZEZySUM0RE11WVdpS0tMWloyVWNXRlhjRUx3Y3YKRUJ1cFBhNHlOamlzWkJEM3AzaG1hMHFPQjFU
+      Tlk4N0s5REZrVWgrN2Mvd2xaTlphcmRiZUlKaWRCMDBWYmNLegpnNWJQOTl0SkZMa1kvaXhJaGdwQ0Vl
+      TDZaVWFCQmJmcDZzNTZsNG1zcUdWaU85RGxvWnBSV1AyMXJPT1dWMDh3CmgyYi9VNStaeTVBTnNmeDVo
+      YUtsajZNcWphbG9DeVZZVktGSERwc2k2c0cxZnF2RjNNYzlWWXJBQmVsZVhGL2IKbnNYMStMWjlFU2py
+      d2pwZVV5SkEyVktPTlQyMHVKQUM3dXRybnJGNjRUdVRIeXFCcTRMY1FQMmNHS21BWVVYOApZUVVhCi0t
+      LS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  failurePolicy: Fail
+  name: mpod.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  sideEffects: None

--- a/webhook/generate-certs.sh
+++ b/webhook/generate-certs.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+openssl genrsa -out ca.key 2048
+
+openssl req -new -x509 -days 365 -key ca.key \
+  -subj "/C=AU/CN=windows-webhook"\
+  -out ca.crt
+
+openssl req -newkey rsa:2048 -nodes -keyout server.key \
+  -subj "/C=AU/CN=windows-webhook" \
+  -out server.csr
+
+openssl x509 -req \
+  -extfile <(printf "subjectAltName=DNS:windows-webhook-webhook-service.windows-webhook-system.svc") \
+  -days 365 \
+  -in server.csr \
+  -CA ca.crt -CAkey ca.key -CAcreateserial \
+  -out server.crt
+
+echo
+echo ">> MutatingWebhookConfiguration caBundle:"
+cat ca.crt | base64 | fold

--- a/webhook/namespace.yaml
+++ b/webhook/namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: windows-webhook
+    app.kubernetes.io/instance: system
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: namespace
+    app.kubernetes.io/part-of: windows-webhook
+    control-plane: controller-manager
+  name: windows-webhook-system

--- a/webhook/runtimeclass.yaml
+++ b/webhook/runtimeclass.yaml
@@ -1,0 +1,14 @@
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: runhcs-wcow-hypervisor
+handler: runhcs-wcow-process
+scheduling:
+  nodeSelector:
+    kubernetes.io/os: 'windows'
+    kubernetes.io/arch: 'amd64'
+  tolerations:
+  - effect: NoSchedule
+    key: os
+    operator: Equal
+    value: "windows"

--- a/webhook/setup.sh
+++ b/webhook/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+windows_nodes=$(kubectl get nodes -l kubernetes.io/os=windows -o jsonpath='{.items[*].metadata.name}')
+for node in $windows_nodes; do
+  echo "Tainting Windows node $node"
+  kubectl taint node "$node" os=windows:NoSchedule --overwrite
+done
+
+echo "Applying runtimeclass.yaml"
+kubectl apply -f runtimeclass.yaml
+
+echo "Installing cert manager"
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
+
+kubectl apply -f namespace.yaml
+
+echo
+echo ">> Generating kube secrets..."
+kubectl create secret tls webhook-server-cert \
+  -n windows-webhook-system \
+  --cert=server.crt \
+  --key=server.key
+
+echo "Installing webhook deployment"
+kubectl apply -f deployment.yaml
+
+echo "Untainting Windows nodes"
+for node in $windows_nodes; do
+  kubectl taint node "$node" os=windows:NoSchedule- --overwrite
+done


### PR DESCRIPTION
#### What type of PR is this?
- New feature/enhancement

#### What this PR does / why we need it:
- We need this PR to specify why and how to implement a webhook to schedule on Windows nodes. People running the tests will encounter issues if a webhook is not implemented before running tests. If not done, it will result in false positives or false negatives whereby a test fails or passes because it was incorrectly scheduled. The webhook image and its associated components have been repurposed from the HyperV tests. It makes sense to reuse the same webhook rather than creating our own since they solve the same problem. Also checked in with Mark regarding this and he mentioned its all good.

Changes included in this PR are
- Update the README with motivation on why webhook is necesary prerequisite
- Add manifest files and scripts for someone to easily setup a Windows node selector mutating webhook

#### Which issue(s) this PR fixes:
- Resolves https://github.com/kubernetes-sigs/windows-operational-readiness/issues/95 by providing intrunctions on the motivation and how to implement a webhook
- Resolves https://github.com/kubernetes-sigs/windows-operational-readiness/issues/69 since EKS has an implicit requirement to provide a node selector otherwise the pod will not get an IP

#### Future enhancements:
Right now the YAML files need to be manually updated. This could be enhanced by using a tool like Kustomize or Helm

#### Testing:
Testedby running the instrunctions provided and successfully deployed the webhook and saw logs demonstrating that the pod was successfully mutated with the node selector as expected. Sample logs as follows.

```
2023-10-24T06:27:48Z	INFO	webhook	Pod  is being mutated
2023-10-24T06:27:48Z	DEBUG	controller-runtime.webhook.webhooks	wrote response	{"webhook": "/mutate-v1-pod", "code": 200, "reason": "", "UID": "1f7f8777-676c-416a-9937-6f1b43cc9fc8", "allowed": true}
2023-10-24T06:29:00Z	DEBUG	controller-runtime.webhook.webhooks	received request	{"webhook": "/mutate-v1-pod", "UID": "b6adabd0-24fe-4b65-aa36-ca08c2df487a", "kind": "/v1, Kind=Pod", "resource": {"group":"","version":"v1","resource":"pods"}}
``` 