### PR TITLE
Remove failing scheduling tests

### DIFF
--- a/specifications/core-scheduling/spec.yaml
+++ b/specifications/core-scheduling/spec.yaml
@@ -1,21 +1,5 @@
 category: Core.Scheduling
 testCases:
-#  These test(s) is commented out because it requires a pod node selector set on the kubernetes test
-#  - description: Ability to create and update a limit range and ensure that pods adhere to specified Limitranges
-#    focus:
-#      - 'should create a LimitRange with defaults and ensure pod has those defaults applied'
-#    skip:
-#      - ''
-#  - description: Ability to demonstrate the pods requesting more CPU and Memory then available are left in the Pending state over time.
-#    focus:
-#      - 'verify pod overhead is accounted for'
-#    skip:
-#      - ''
-#  - description: Ability to preempt a lower priority pod in favor of scheduling higher priority pod
-#    focus:
-#      - 'validates basic preemption works'
-#    skip:
-#      - ''
   - description: Ability to not exceed pod memory limits and should fail once there isn't enough memory
     focus:
       - '\[Feature\:Windows\] Memory Limits'


### PR DESCRIPTION
## What type of PR is this?
New enhancement

## What this PR does / why we need it:
**TLDR: Removes 3 test cases to be ready for initial ops readiness release**

This PR is part of an effort to achieve a minimal set of test cases that will be part of an initial release. As part of this effort, `sig-windows` team is going category by category and finalizing on which test cases are appropriate for the initial release.

I removed three commented-out test cases. 

#### Irrelevant test cases removed
Two of three of the test cases, were more suited to verifying the behaviour of the Kubernetes scheduler, which is a control plane component, rather than specifically testing Windows nodes within the data plane. These can be removed.
1. Ability to preempt a lower priority pod in favor of scheduling higher priority pod
2. Ability to demonstrate the pods requesting more CPU and Memory then available are left in the Pending state over time

#### Relevant test cases removed
One of the three test cases was well suited for testing against a Windows node, but during my tests on AWS EKS, the test was failing because of a specific manner in which the test is written, than the fact the Windows node is failing the tests. More specifically, the test is failing with the following log.
```
2023-12-05T00:41:48-08:00       INFO    [sig-scheduling] LimitRange [It] should create a LimitRange with defaults and ensure pod has those defaults applied. [Conformance]
...
2023-12-05T00:41:48-08:00       INFO      [FAILED] resource [vpc.amazonaws.com/PrivateIPv4Address](http://vpc.amazonaws.com/PrivateIPv4Address) expected 0 actual 1
2023-12-05T00:41:48-08:00       INFO      In [It] at: test/e2e/scheduling/limit_range.go:137 @ 12/05/23 00:41:47.876
```

The reason for the failure is that the [AWS EKS VPC Resource Controller](https://github.com/aws/amazon-vpc-resource-controller-k8s) updates a field that the test case does not expect to be updated. This field has to be updated in order for AWS EKS IP address management to work as expected and is by design. Added an issue https://github.com/kubernetes-sigs/windows-operational-readiness/issues/101 to track this as technical debt for a future ops readiness release. I am currently testing op-readiness using AWS EKS and therefore have no other means of verifying this functionality and the issue will have to be addressed at a later time.

## Which issue(s) this PR fixes:
Resolves https://github.com/kubernetes-sigs/windows-operational-readiness/issues/73 to finish updating scheduling tests to be ready for the initial release of ops-readines